### PR TITLE
Make withReact accept multiple tags.

### DIFF
--- a/R/jsx.R
+++ b/R/jsx.R
@@ -152,14 +152,14 @@ make_react_render_tags <- function(serialized_tags, dependencies, target_id) {
   )
 }
 
-prepare_for_rendering <- function(mixed_tags) {
-  mixed_tags <- ShinyComponentWrapper(mixed_tags)
+prepare_for_rendering <- function(...) {
+  mixed_tags <- ShinyComponentWrapper(...)
   dependencies <- c(
     all_shiny_react_dependencies(),
     htmltools::findDependencies(mixed_tags)
   )
 
-  serialized <- serialize_shiny_react_tags(mixed_tags, pretty_print = is_debug_mode()) # nolint
+  serialized <- serialize_shiny_react_tags(mixed_tags, pretty_print = is_debug_mode())
 
   logger::log_debug("Tags representation prepared for rendering:\n\n{serialized}")
 
@@ -176,14 +176,13 @@ prepare_for_rendering <- function(mixed_tags) {
 #'
 #' This function is named in camelCase for consistency with Shiny naming convention.
 #'
-#' @param mixed_tags A htmltools tag object that can also contain React tags. tagLists are not currently supported.
+#' @param ... One or more tag objects which can be a mix of Shiny (htmltools) and React tags.
 #'
 #' @export
-withReact <- function( # nolint
-                      mixed_tags) {
+withReact <- function(...) { # nolint
   id <- generate_random_container_id()
 
-  serialized <- prepare_for_rendering(mixed_tags)
+  serialized <- prepare_for_rendering(...)
   make_react_render_tags(serialized$tags_json, serialized$dependencies, id)
 }
 

--- a/man/enable_react_debug_mode.Rd
+++ b/man/enable_react_debug_mode.Rd
@@ -7,6 +7,6 @@
 enable_react_debug_mode()
 }
 \description{
-Sets the \code{shiny.react_DEBUG} option to \code{value}. In DEBUG mode, shiny.react will load a dev version of JS code including React,
-which is useful for debugging. It will also set a DEBUG logging level and pretty print tags representation sent to client.
+Sets the \code{shiny.react_DEBUG} option to \code{value}. In DEBUG mode, shiny.react will load a dev version of React,
+which is useful for debugging. It will also set a DEBUG logging level and pretty print tags sent to client.
 }

--- a/man/withReact.Rd
+++ b/man/withReact.Rd
@@ -4,10 +4,10 @@
 \alias{withReact}
 \title{Use arbitrary React components and props in R.}
 \usage{
-withReact(mixed_tags)
+withReact(...)
 }
 \arguments{
-\item{mixed_tags}{A htmltools tag object that can also contain React tags. tagLists are not currently supported.}
+\item{...}{One or more tag objects which can be a mix of Shiny (htmltools) and React tags.}
 }
 \description{
 Wrap your tags with this function to enable using a mix of HTML and React tags.

--- a/tests/testthat/test-jsx.R
+++ b/tests/testthat/test-jsx.R
@@ -165,6 +165,27 @@ test_that("withReact adds a ShinyComponentWrapper around tags", {
   expect_equal(result, a_result)
 })
 
+test_that("withReact accepts multiple arguments", {
+  # given
+  a_result <- "result"
+  an_id <- "some_id"
+  first_tag <- htmltools::tags$div("a")
+  second_tag <- htmltools::tags$div("b")
+
+  make_react_render_tags_mock <- mock(a_result)
+  stub(withReact, "make_react_render_tags", make_react_render_tags_mock)
+  stub(withReact, "generate_random_container_id", an_id)
+
+  # when
+  result <- withReact(first_tag, second_tag)
+
+  # then
+  serialized_text <- serialize_shiny_react_tags(ShinyComponentWrapper(first_tag, second_tag))
+  expected_serialized <- structure(serialized_text, class = "json")
+  expect_args(make_react_render_tags_mock, 1, expected_serialized, all_shiny_react_dependencies(), an_id)
+  expect_equal(result, a_result)
+})
+
 test_that("mark_js_attribs_as_raw_json marks the entire attribute if it is JS", {
   a_content <- "abc"
   attribs <- list(attribute = JS(a_content))


### PR DESCRIPTION
## Changes description (include a screenshot if applicable!)
Make it possible to write `withReact(div('a'), div('b'))` 

previously we had to write `withReact(div(div('a'), div('b')))` or similar

## Definition of Done checklist
- [x] :spiral_notepad: README, other documentation and code comments that we have is updated with all information related to the change.
- [x] Unit tests added for all new or changed logic.
- [ ] End-to-end tests added for all new or changed logic.
