### PR TITLE
Passing tibble to updateReactInput doesn't break components

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
   htmltools,
   jsonlite,
   logger,
+  purrr,
   rlang,
   shiny
 Suggests:

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 S3method(asReactData,JS_EVAL)
 S3method(asReactData,ReactData)
+S3method(asReactData,data.frame)
 S3method(asReactData,default)
 S3method(asReactData,html_dependency)
 S3method(asReactData,list)

--- a/R/reactData.R
+++ b/R/reactData.R
@@ -61,6 +61,9 @@ asReactData.list <- function(x) {
 }
 
 #' @export
+asReactData.data.frame <- function(x) asReactData(purrr::transpose(x)) # nolint
+
+#' @export
 asReactData.shiny.tag <- function(x) { # nolint
   # A `shiny.tag` created with `reactContainer()` will have a `reactData` attribute attached
   # with a ReactData representation of whatever was supposed to be rendered in the container.


### PR DESCRIPTION
Closes Appsilon/shiny.fluent#65

## Changes description (include a screenshot if applicable!)

When `tibble` is passed to `updateReactInput` it is treated as a `raw` object (`asReactData.default` is called), which is then misinterpreted by JS. Converting `tibble` to a `list` solves the issue. 

## Definition of Done checklist
- [x] :spiral_notepad: README, other documentation and code comments that we have is updated with all information related to the change.
- [ ] Unit tests added for all new or changed logic.
- [ ] End-to-end tests added for all new or changed logic.
