### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,10 +3,12 @@ Title: Tools for Using React in Shiny
 Version: 0.2.3
 Authors@R:
   c(
-    person(given = "Kamil", family = "Zyla", role = c("aut", "cre"), email = "kamil@appsilon.com"),
+    person(given = "Kamil", family = "Zyla", role = "aut", email = "kamil@appsilon.com"),
     person(given = "Marek", family = "Rogala", role = "aut", email = "marek@appsilon.com"),
-    person(given = "Appsilon sp. z o.o.", role = "cph")
+    person("Developers", "Appsilon", email = "support+opensource@appsilon.com", role = "cre"),
+    person(family = "Appsilon Sp. z o.o.", role = "cph")
   )
+URL: https://appsilon.github.io/shiny.react, https://github.com/Appsilon/shiny.react
 Description:
   A toolbox for defining React component wrappers which can be used seamlessly in Shiny apps.
 License: LGPL (>= 3)


### PR DESCRIPTION
Closes #30 

## Changes proposed in this pull request:
- Change maintainer to `support+opensource@appsilon.com`
- Add copyright holder `Appsilon sp. z o.o.`
- Add URL field to contain https://appsilon.github.io/shiny.fluent/ and https://github.com/Appsilon/shiny.react

## Acceptance criteria:
- [x] Ensure that the CRAN entry contains a link to https://appsilon.github.io/shiny.fluent/
- [x] Use opensource@appsilon.com as maintainer email.

Fields are compliant with [shiny.semantic DESCRIPTION](https://github.com/Appsilon/shiny.semantic/blob/develop/DESCRIPTION) and [semantic.dashboard DESCRIPTION](https://github.com/Appsilon/semantic.dashboard/blob/develop/DESCRIPTION)
