### PR TITLE
Update to lintr v3

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,5 @@
 linters:
-  with_defaults(
+  linters_with_defaults(
     line_length_linter(100),
-    object_name_linter("camelCase"),
-    object_usage_linter = NULL
+    object_name_linter("camelCase")
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Imports:
 Suggests:
   knitr,
   leaflet,
-  lintr,
+  lintr (>= 3.0.0),
   mockery (>= 0.4.2),
   rmarkdown,
   styler,

--- a/R/experimental.R
+++ b/R/experimental.R
@@ -1,8 +1,10 @@
 testComponent <- function(name) {
-  function(...) reactElement(
-    module = "@/shiny.react/test-components", name = name,
-    props = asProps(...)
-  )
+  function(...) {
+    reactElement(
+      module = "@/shiny.react/test-components", name = name,
+      props = asProps(...)
+    )
+  }
 }
 
 # nolint start

--- a/R/react.R
+++ b/R/react.R
@@ -155,9 +155,11 @@ JS <- function(...) { # nolint
 #' @return A `ReactData` object which can be passed as a prop to 'React' components.
 #'
 #' @export
-triggerEvent <- function(inputId) ReactData(
-  type = "input", id = inputId, argIdx = NULL
-)
+triggerEvent <- function(inputId) {
+  ReactData(
+    type = "input", id = inputId, argIdx = NULL
+  )
+}
 
 #' Set input
 #'
@@ -169,6 +171,8 @@ triggerEvent <- function(inputId) ReactData(
 #' @return A `ReactData` object which can be passed as a prop to 'React' components.
 #'
 #' @export
-setInput <- function(inputId, argIdx = 1) ReactData(
-  type = "input", id = inputId, argIdx = argIdx - 1
-)
+setInput <- function(inputId, argIdx = 1) {
+  ReactData(
+    type = "input", id = inputId, argIdx = argIdx - 1
+  )
+}

--- a/R/reactData.R
+++ b/R/reactData.R
@@ -11,25 +11,31 @@ asReactData <- function(x) UseMethod("asReactData")
 asReactData.ReactData <- function(x) x
 
 #' @export
-asReactData.default <- function(x) ReactData(
-  type = "raw",
-  value = dropDeps(x),
-  deps = getDeps(x)
-)
+asReactData.default <- function(x) {
+  ReactData(
+    type = "raw",
+    value = dropDeps(x),
+    deps = getDeps(x)
+  )
+}
 
 #' @export
-asReactData.html_dependency <- function(x) ReactData(
-  type = "raw",
-  value = NULL,
-  deps = x
-)
+asReactData.html_dependency <- function(x) {
+  ReactData(
+    type = "raw",
+    value = NULL,
+    deps = x
+  )
+}
 
 #' @export
-asReactData.JS_EVAL <- function(x) ReactData(
-  type = "expr",
-  value = dropDeps(unclass(x)),
-  deps = getDeps(x)
-)
+asReactData.JS_EVAL <- function(x) {
+  ReactData(
+    type = "expr",
+    value = dropDeps(unclass(x)),
+    deps = getDeps(x)
+  )
+}
 
 checkNames <- function(x) {
   # `toJson()` converts named lists to JSON objects, and unnamed lists to JSON arrays. A list `x`
@@ -77,7 +83,9 @@ asReactData.shiny.tag <- function(x) { # nolint
       props = dropDeps(props),
       deps = list(getDeps(props), getDeps(x))
     )
-  } else data
+  } else {
+    data
+  }
 }
 
 #' @export

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -2,11 +2,13 @@ toJson <- function(
   x, ...,
   auto_unbox = TRUE, json_verbatim = TRUE, # nolint
   Date = "ISO8601", POSIXt = "ISO8601", null = "null", na = "null" # nolint
-) jsonlite::toJSON(
-  x, ...,
-  auto_unbox = auto_unbox, json_verbatim = json_verbatim,
-  Date = Date, POSIXt = POSIXt, null = null, na = na
-)
+) {
+  jsonlite::toJSON(
+    x, ...,
+    auto_unbox = auto_unbox, json_verbatim = json_verbatim,
+    Date = Date, POSIXt = POSIXt, null = null, na = na
+  )
+}
 
 addChildrenToProps <- function(props, children) {
   if (length(children) > 0) {


### PR DESCRIPTION
### Changes
1. Require `lintr >= 3.0.0` in `DESCRIPTION`.
2. Update `.lintr` configuration.
3. Fix linter errors.

### How to test
The CI should pass.