### PR TITLE
Update and fix the pkgdown workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+### Changes
+
+Closes #
+
+### How to test

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,0 @@
-CU-IN-XX[closed]
-
-## Changes description (include a screenshot if applicable!)
-
-## Definition of Done checklist
-- [ ] :spiral_notepad: README, other documentation and code comments that we have is updated with all information related to the change.
-- [ ] Unit tests added for all new or changed logic.
-- [ ] End-to-end tests added for all new or changed logic.

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,48 +1,36 @@
+name: pkgdown
 on:
   push:
-    branches:
-      - main
-      - master
-
-name: pkgdown
-
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
 jobs:
-  pkgdown:
-    runs-on: macOS-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+  main:
+    name: Build and publish website
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@v1
-
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
-
-      - name: Restore R package cache
-        uses: actions/cache@v2
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          use-public-rspm: true # Dramatically speeds up installation of dependencies.
 
-      - name: Install dependencies
+      - name: Install R package dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+
+      - name: Configure git
         run: |
-          remotes::install_deps(dependencies = TRUE)
-          install.packages("pkgdown", type = "binary")
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Build and deploy site
         shell: Rscript {0}
-
-      - name: Install package
-        run: R CMD INSTALL .
-
-      - name: Deploy package
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'
+        run: pkgdown::deploy_to_branch()
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

1. Replace the `pkgdown` workflow with one based on [Rhino](https://github.com/Appsilon/rhino/blob/main/.github/workflows/pkgdown.yml).
2. Update the PR template.

### Testing

See a [sample run](https://github.com/Appsilon/shiny.react/actions/runs/5287036123/jobs/9567058746) of this workflow and its results on the [test/gh-pages](https://github.com/Appsilon/shiny.react/tree/test/gh-pages) branch.