### PR TITLE
Add gitattributes file to hide react code from stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+inst/www/react/* linguist-generated=true
+inst/www/shiny.react/* linguist-generated=true


### PR DESCRIPTION
### Changes

Closes #48

It seems that repository language stats are only calculated for `main` (default branch?), I don't know how to test it.

![image](https://github.com/Appsilon/shiny.react/assets/37193264/15bf891b-9fed-41e3-9086-8f8c4369e8c3)

